### PR TITLE
fix: use string over String

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,16 +4,16 @@ Get emojis from a string
 */
 
 type Emojis = {
-    name: String,
-    id: String,
-    animated: Boolean,
-    image: String,
+    name: string,
+    id: string,
+    animated: boolean,
+    image: string,
     type: "Discord Emoji" | "Default Emoji"
 }
 
 type Options = {
-    onlyDiscordEmojis?: Boolean,
-    onlyDefaultEmojis?: Boolean
+    onlyDiscordEmojis?: boolean,
+    onlyDefaultEmojis?: boolean
 }
 
 declare function getEmojisFromString(


### PR DESCRIPTION
Hello, 'string' is a primitive type, and 'String' is a wrapper object. We need to use 'string' in that case. This makes the package incompatible with my project..! Hope this gets merged, thank you for your time ;)